### PR TITLE
Fixed decompiler exception which is thrown in case there are referenc…

### DIFF
--- a/ICSharpCode.Decompiler/ILAst/ILAstBuilder.cs
+++ b/ICSharpCode.Decompiler/ILAst/ILAstBuilder.cs
@@ -296,7 +296,11 @@ namespace ICSharpCode.Decompiler.ILAst {
 				}
 				ILCode code = ilCodeTranslation[inst.OpCode.Code];
 				object operand = inst.Operand;
-				ILCodeUtil.ExpandMacro(ref code, ref operand, methodDef);
+				ILCode codeBkp = code;
+				if (!ILCodeUtil.ExpandMacro(ref code, ref operand, methodDef)) {
+					code = codeBkp;
+					operand = inst.Operand;
+				}
 				ByteCode byteCode = new ByteCode() {
 					Offset      = inst.Offset,
 					EndOffset   = next?.Offset ?? (uint)methodDef.Body.GetCodeSize(),

--- a/ICSharpCode.Decompiler/ILAst/ILCodes.cs
+++ b/ICSharpCode.Decompiler/ILAst/ILCodes.cs
@@ -423,10 +423,11 @@ namespace ICSharpCode.Decompiler.ILAst {
 				boxedSBytes_Int32[i] = (int)(sbyte)(i + sbyte.MinValue);
 		}
 
-		public static void ExpandMacro(ref ILCode code, ref object operand, MethodDef method)
+		public static bool ExpandMacro(ref ILCode code, ref object operand, MethodDef method)
 		{
 			var methodBody = method.Body;
-			switch (code) {
+			try {
+				switch (code) {
 					case ILCode.Ldarg_0:   code = ILCode.Ldarg; operand = method.Parameters[0]; break;
 					case ILCode.Ldarg_1:   code = ILCode.Ldarg; operand = method.Parameters[1]; break;
 					case ILCode.Ldarg_2:   code = ILCode.Ldarg; operand = method.Parameters[2]; break;
@@ -487,7 +488,12 @@ namespace ICSharpCode.Decompiler.ILAst {
 					case ILCode.Stind_I8:  code = ILCode.Stobj; operand = method.Module.CorLibTypes.Int64.TypeDefOrRef; break;
 					case ILCode.Stind_R4:  code = ILCode.Stobj; operand = method.Module.CorLibTypes.Single.TypeDefOrRef; break;
 					case ILCode.Stind_R8:  code = ILCode.Stobj; operand = method.Module.CorLibTypes.Double.TypeDefOrRef; break;
+				}
 			}
+			catch (System.ArgumentOutOfRangeException) {
+				return false;
+			}
+			return true;
 		}
 	}
 }

--- a/README.md
+++ b/README.md
@@ -17,17 +17,32 @@ Copyright 2011-2016 AlphaSierraPapa for the SharpDevelop team
 License: ILSpy is distributed under the MIT License.
 
 Included open-source libraries:
- Mono.Cecil: MIT License (thanks to Jb Evain)
- AvalonEdit: LGPL
- SharpTreeView: LGPL
- ICSharpCode.Decompiler: MIT License (developed as part of ILSpy)
- Ricciolo.StylesExplorer: MS-PL (part of ILSpy.BamlDecompiler.Plugin)
+
+  * Mono.Cecil: MIT License (thanks to Jb Evain)
+
+  * AvalonEdit: LGPL
+
+  * SharpTreeView: LGPL
+
+  * ICSharpCode.Decompiler: MIT License (developed as part of ILSpy)
+
+  * Ricciolo.StylesExplorer: MS-PL (part of ILSpy.BamlDecompiler.Plugin)
+
 
 ILSpy Contributors:
-	Daniel Grunwald
-	David Srbecky
-	Ed Harvey
-	Siegfried Pammer
-	Artur Zgodzinski
-	Eusebiu Marcu
-	Pent Ploompuu
+
+  * Daniel Grunwald
+	
+  * David Srbecky
+	
+  * Ed Harvey
+	
+  * Siegfried Pammer
+	
+  * Artur Zgodzinski
+	
+  * Eusebiu Marcu
+	
+  * Pent Ploompuu
+	
+  * Aliaksandr Trafimchuk (from Check Point Software Technologies)


### PR DESCRIPTION
…ed non-existent variables/arguments (usually produced by the obfuscators). Previously, it failed to decompile such code, like is shown below:
![dnspy_sympthoms](https://user-images.githubusercontent.com/37109189/40678241-ac50e3f8-6388-11e8-924f-e17c5e0e55f1.png)